### PR TITLE
Replace border with box-shadow

### DIFF
--- a/src/Plugin.cpp
+++ b/src/Plugin.cpp
@@ -19,8 +19,8 @@ namespace Plugin
 
 		gtk_container_add(GTK_CONTAINER(xfPlugin), GTK_WIDGET(Taskbar::mBoxWidget));
 
-		Glib::ustring data = "button.opened { border-bottom: 2px solid shade(@theme_selected_bg_color, 0.75); }"
-		"button.active { border-bottom: 2px solid shade(@theme_selected_bg_color, 1.15); }"
+		Glib::ustring data = "button.opened { box-shadow: inset 0px -1px shade(@theme_selected_bg_color, 0.75); }"
+		"button.active { box-shadow: inset 0px -1px shade(@theme_selected_bg_color, 1.15); }"
 		"button.drop { border-left: 5px solid @theme_selected_bg_color; }";
 
 		Glib::RefPtr<Gtk::CssProvider> cssProvider = Gtk::CssProvider::create();


### PR DESCRIPTION
Otherwise the icons are moved around when launching an application, in
other words: when an app is opened, the icon is moved 2px up if
bottom-border is set to 2px. box-shadow avoids this.

I went back to the 1px width of the "active/open" indicator line, feel free to bump that back to 2px for better visibility.